### PR TITLE
docs(filter): clarify Outline Type modes (FILTER-DR-001)

### DIFF
--- a/elements/components/filter.md
+++ b/elements/components/filter.md
@@ -39,7 +39,7 @@ Set the input text colour, opacity, font, size, weight, letter spacing, line hei
 
 #### Outline
 
-Outline controls style the focus outline shown around the search field. Keep a visible focus indicator for keyboard users.
+The Outline group draws an outline around the search field. **Type** defaults to None: **Static** shows one outline at all times; **Focus** provides separate Unfocused and Focused states. Keep a visible Focus state for keyboard users.
 
 ### Accessibility
 


### PR DESCRIPTION
## Summary
- **FILTER-DR-001**: Replace focus-only Outline wording with Type modes (None / Static / Focus), matching shared Outline behaviour and the Forms Input page pattern.

## Test plan
- [ ] Confirm Outline section on Filter page names Type defaults and Static vs Focus
- [ ] Spot-check GitBook rendering of bold **Type** / **Static** / **Focus**

RWAI fix-run log: `audit/fix/doc-review/Fix-Run-2026-08-06-3.md`

Made with [Cursor](https://cursor.com)