### PR TITLE
Document Reveal Play/Start/End trigger semantics

### DIFF
--- a/elements/components/reveal.md
+++ b/elements/components/reveal.md
@@ -37,9 +37,8 @@ You’ll find Reveal under **Animation** in the Components list.
 
 **Trigger**
 
-* **Play** — Choose Once on Enter, Always on Enter, or Enter and Exit. The default is Enter and Exit.
-* **Start** — Choose Entering Screen, Middle of Screen, or Exiting Screen. The default is Entering Screen.
-* **End** — Uses the same positions and defaults to Exiting Screen.
+* **Play** — When the animation runs. **Once on Enter** plays it the first time the content enters the viewport and never again; **Always on Enter** replays it each time the content scrolls into view from below; **Enter and Exit** (the default) also plays a matching exit animation when the content leaves, and replays on re-entry in either direction.
+* **Start** / **End** — Where the animation is triggered, measured against the top edge of the Reveal content: **Entering Screen** as it reaches the bottom of the viewport, **Middle of Screen** as it reaches the centre, and **Exiting Screen** as it reaches the top. Start defaults to Entering Screen; End defaults to Exiting Screen. In Scrub mode the animation progresses between the Start and End positions.
 
 **Timing**
 


### PR DESCRIPTION
## Summary
- **REVEAL-DR-001** — Expand Play / Start / End docs so Once on Enter, Always on Enter, and Enter and Exit behaviour is explicit, and Start/End positions are described relative to the content’s top edge (including Scrub mode).

## Test plan
- [ ] Read Trigger section on the Reveal component page
- [ ] Confirm Play options match Smooth-mode ScrollTrigger behaviour
- [ ] Confirm Start/End wording matches `entering-screen` / `middle-of-screen` / `exiting-screen` mappings

RWAI fix-run log: `audit/fix/doc-review/Fix-Run-2026-08-06-4.md`


Made with [Cursor](https://cursor.com)