### PR TITLE
Clarify Video thumbnail CMS Twig field requirement

### DIFF
--- a/elements/components/video.md
+++ b/elements/components/video.md
@@ -65,6 +65,8 @@ When enabled, **Color** defaults to Black, **Opacity** to 50%, and **Blur** to 0
 
 **Mode** switches between Light and Dark thumbnail sources. Custom uses a URL or path; CMS uses a field expression defaulting to `{{item.image.src}}`.
 
+As with the [Image](image.md) component, the CMS field must be a Twig expression that outputs the image's URL, like the default `{{item.image.src}}` — a front matter key on its own won't work.
+
 Custom and CMS thumbnails provide **Alt** text.
 
 **Overlay Color** defaults to Surface 50 and **Opacity** to 50%.


### PR DESCRIPTION
## Summary
- **VIDEO-DR-001**: Document that the Video thumbnail CMS field must be a Twig expression resolving to an image URL (same contract as Image / shared PosterImage control), not a bare front matter key.

## Test plan
- [ ] Read Thumbnail section of `elements/components/video.md` — Twig URL sentence appears after the Mode/CMS sentence and links to `image.md`
- [ ] Confirm wording matches shared Image CMS field behaviour (`{{item.image.src}}`)

RWAI log: `audit/fix/doc-review/Fix-Run-2026-08-06-5.md`


Made with [Cursor](https://cursor.com)