### PR TITLE
Docs: Drop Shadow vs Box Shadow distinction (CONTROL-FILTERS-DR-001)

### DIFF
--- a/elements/components/common-controls/effects.md
+++ b/elements/components/common-controls/effects.md
@@ -48,6 +48,8 @@ For Static and each Hover state:
 * **Color** — Overrides the shadow colour and defaults to None.
 * **Opacity** — Controls shadow-colour opacity from 0–100% and defaults to 100%.
 
+Unlike the Drop Shadow in [Filters](filters.md), a box shadow follows the component’s rectangular box rather than the visible shape of transparent PNGs or SVGs.
+
 ### Opacity
 
 The component **Opacity** ranges from 0–100% and defaults to 100% for Static and both Hover states.

--- a/elements/components/common-controls/filters.md
+++ b/elements/components/common-controls/filters.md
@@ -34,7 +34,7 @@ Static and each Hover state provide:
 * **Blur** — Defaults to 0 pixels.
 * **Brightness** — Defaults to 100%. Lower values darken; higher values brighten.
 * **Saturate** — Defaults to 100%. `0` removes colour; values above 100 increase saturation.
-* **Drop Shadow** — Defaults to None and uses Theme Studio shadow values.
+* **Drop Shadow** — Defaults to None and uses Theme Studio shadow values. Unlike the Box Shadow in [Effects](effects.md), a drop shadow follows the visible shape of the content — including the transparent areas of PNGs and SVGs — rather than its rectangular box.
 
 ### Backdrop Filters
 


### PR DESCRIPTION
## Summary
- **CONTROL-FILTERS-DR-001** — Document that Filters Drop Shadow follows the visible content shape (PNGs/SVGs), unlike Effects Box Shadow which follows the rectangular box; add reverse cross-reference on Effects.

## Test plan
- [ ] Confirm Drop Shadow bullet on `common-controls/filters.md` links to Effects and states the shape difference
- [ ] Confirm Box Shadow section on `common-controls/effects.md` links back to Filters

RWAI fix-run log: `audit/fix/doc-review/Fix-Run-2026-08-06-7.md`


Made with [Cursor](https://cursor.com)