### PR TITLE
Document Image CMS Field Twig URL requirement

### DIFF
--- a/elements/components/image.md
+++ b/elements/components/image.md
@@ -38,6 +38,8 @@ The dark image is shown automatically when the visitor’s browser or operating 
 
 Custom mode displays **Source**. CMS mode displays **Field**, which defaults to `{{item.image.src}}`. Both modes provide **Alt** text.
 
+The Field value must be a Twig expression that outputs the image's URL, like the default `{{item.image.src}}`. Typing a front matter key on its own (for example `image`) won't work — wrap it as an expression, e.g. `{{item.image}}` if your front matter stores the URL directly.
+
 {% hint style="info" %}
 CMS images show a placeholder while editing. Preview or publish the page to see the resolved CMS image.
 {% endhint %}


### PR DESCRIPTION
## Summary
- **IMAGE-DR-006**: State that the Image CMS Field must be a Twig expression resolving to an image URL (not a bare front matter key), matching how the Field value is emitted as `src`.

## Test plan
- [ ] Confirm `elements/components/image.md` Field section includes the Twig expression rule after the Field defaults sentence
- [ ] Spot-check against Video thumbnail CMS wording for consistency

RWAI fix-run log: `audit/fix/doc-review/Fix-Run-2026-08-06-8.md`


Made with [Cursor](https://cursor.com)