### PR TITLE
Docs: Clarify Flex Justify Items (FLEX-DR-005)

### DIFF
--- a/elements/components/flex.md
+++ b/elements/components/flex.md
@@ -71,8 +71,11 @@ Defaults to Normal.
 * **Between**, **Around**, **Evenly** — Spreads the spare space between, around, or evenly among the children.
 * **Stretch** — Children grow to fill the main axis where they have no fixed size.
 
-**Items** sets the default inline-axis alignment of each child within its own area.
-Defaults to Normal. Options are Normal, Start, End, Center, and Stretch.
+**Items** maps to the CSS `justify-items` property, which sets the default inline-axis
+alignment of each child within its own area. It is honoured by grid layouts; in a Flex
+container the main-axis distribution comes from Justify Content instead. Use
+[Grid](grid.md) when you need per-item justification. Defaults to Normal. Options are
+Normal, Start, End, Center, and Stretch.
 
 #### Link
 


### PR DESCRIPTION
## Summary
- Clarify that Justify **Items** maps to CSS `justify-items`, which grid honours and Flex ignores for main-axis distribution (FLEX-DR-005)
- Point authors to Grid when they need per-item justification; keep Normal default and option list from FLEX-DR-001

RWAI fix-run log: `audit/fix/doc-review/Fix-Run-2026-08-06-9.md`

## Test plan
- [ ] Read Flex → Justify → Items and confirm it no longer says “where supported”
- [ ] Confirm Grid cross-link works and Content/Items option lists remain intact
- [ ] Confirm GitBook frontmatter / embeds / includes unchanged


Made with [Cursor](https://cursor.com)